### PR TITLE
Feature/rollbar reporting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v0.2.0 - 2018-08-14
-- Added rollbar as option for warnings. Can be passed true, false, 'auto'
+- Added rollbar as option for warnings. Can be passed true, false, `:auto`
 - Auto attempts to warn if rollbar is present, does nothing if not present
 - Added 'auto' as an option for active-support-deprecation
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## v0.1.3 - 2018-08-14
+## v0.2.0 - 2018-08-14
 - Added rollbar as option for warnings. Can be passed true, false, 'auto'
 - Auto attempts to warn if rollbar is present, does nothing if not present
 - Added 'auto' as an option for active-support-deprecation

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v0.1.3 - 2018-08-14
-- Added rollbar as option for warnings
+- Added rollbar as option for warnings. Can be passed true, false, 'auto'
+- Auto attempts to warn if rollbar is present, does nothing if not present
+- Added 'auto' as an option for active-support-deprecation
 
 ## v0.1.2 - 2017-02-20
 ### Fixed

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## v0.1.3 - 2018-08-14
+- Added rollbar as option for warnings
+
 ## v0.1.2 - 2017-02-20
 ### Fixed
 - Loosen faraday dependency to `< 1` to add support for v0.14

--- a/README.md
+++ b/README.md
@@ -39,16 +39,21 @@ connection = Faraday.new(url: '...') do |conn|
   # or
   conn.response :sunset, logger: Rails.logger
   # or
-  conn.response :sunset, rollbar: 'on'
+  conn.response :sunset, rollbar: true
 end
 ```
 
-You can [configure `ActiveSupport::Deprecation`][active-support-deprecation] to warn in a few different ways, or pass in any object that acts a bit like a Rack logger, Rails logger, or anything with a `warn` method that takes a string.
+For `logger`, You can pass in any object that acts a bit like a Rack logger, Rails logger, or anything with a `warn` method that takes a string.
+
+You can [configure `ActiveSupport::Deprecation`][active-support-deprecation] to warn in 3 ways:
+- true:   throw warnings on sunsetted endpoints, and throw an error if active-support is missing from the project
+- 'auto': throw warnings on sunsetted endpoints, and ignore if active-support is missing from the project
+- false: ignore active-support
 
 You can [configure `Rollbar`][rollbar] in 3 ways:
-- 'on':   throw warnings on sunsetted endpoints, and throw an error if Rollbar is missing from the project
-- 'auto': throw warnings on sunsetted endpoints, but do NOT throw errors if Rollbar is missing from the project
-- 'off': do not throw rollbar errors
+- true:   throw warnings on sunsetted endpoints, and throw an error if Rollbar is missing from the project
+- 'auto': throw warnings on sunsetted endpoints, and ignore if Rollbar is missing from the project
+- false: ignore Rollbar
 
 [active-support-deprecation]: http://api.rubyonrails.org/classes/ActiveSupport/Deprecation/Behavior.html
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,17 @@ connection = Faraday.new(url: '...') do |conn|
   conn.response :sunset, active_support: true
   # or
   conn.response :sunset, logger: Rails.logger
+  # or
+  conn.response :sunset, rollbar: 'on'
 end
 ```
 
 You can [configure `ActiveSupport::Deprecation`][active-support-deprecation] to warn in a few different ways, or pass in any object that acts a bit like a Rack logger, Rails logger, or anything with a `warn` method that takes a string.
+
+You can [configure `Rollbar`][rollbar] in 3 ways:
+- 'on':   throw warnings on sunsetted endpoints, and throw an error if Rollbar is missing from the project
+- 'auto': throw warnings on sunsetted endpoints, but do NOT throw errors if Rollbar is missing from the project
+- 'off': do not throw rollbar errors
 
 [active-support-deprecation]: http://api.rubyonrails.org/classes/ActiveSupport/Deprecation/Behavior.html
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ connection = Faraday.new(url: '...') do |conn|
   conn.response :sunset, logger: Rails.logger
   # or
   conn.response :sunset, rollbar: true
+  # or combine:
+  conn.response :sunset, rollbar: :auto, active_support: true, logger: Rails.logger
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ For `logger`, You can pass in any object that acts a bit like a Rack logger, Rai
 
 You can [configure `ActiveSupport::Deprecation`][active-support-deprecation] to warn in 3 ways:
 - true:   throw warnings on sunsetted endpoints, and throw an error if active-support is missing from the project
-- 'auto': throw warnings on sunsetted endpoints, and ignore if active-support is missing from the project
+- :auto : throw warnings on sunsetted endpoints, and ignore if active-support is missing from the project
 - false: ignore active-support
 
 You can [configure `Rollbar`][rollbar] in 3 ways:
 - true:   throw warnings on sunsetted endpoints, and throw an error if Rollbar is missing from the project
-- 'auto': throw warnings on sunsetted endpoints, and ignore if Rollbar is missing from the project
+- :auto : throw warnings on sunsetted endpoints, and ignore if Rollbar is missing from the project
 - false: ignore Rollbar
 
 [active-support-deprecation]: http://api.rubyonrails.org/classes/ActiveSupport/Deprecation/Behavior.html

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ end
 For `logger`, You can pass in any object that acts a bit like a Rack logger, Rails logger, or anything with a `warn` method that takes a string.
 
 You can [configure `ActiveSupport::Deprecation`][active-support-deprecation] to warn in 3 ways:
-- true:   throw warnings on sunsetted endpoints, and throw an error if active-support is missing from the project
-- :auto : throw warnings on sunsetted endpoints, and ignore if active-support is missing from the project
-- false: ignore active-support
+- `true` - throw warnings on sunsetted endpoints, and throw an error if active-support is missing from the project
+- `false` - ignore active-support
+- `:auto` - throw warnings on sunsetted endpoints, and ignore if active-support is missing from the project
 
 You can [configure `Rollbar`][rollbar] in 3 ways:
-- true:   throw warnings on sunsetted endpoints, and throw an error if Rollbar is missing from the project
-- :auto : throw warnings on sunsetted endpoints, and ignore if Rollbar is missing from the project
-- false: ignore Rollbar
+- `true` - throw warnings on sunsetted endpoints, and throw an error if active-support is missing from the project
+- `false` - ignore rollbar
+- `:auto` - throw warnings on sunsetted endpoints, and ignore if Rollbar is missing from the project
 
 [active-support-deprecation]: http://api.rubyonrails.org/classes/ActiveSupport/Deprecation/Behavior.html
 

--- a/faraday-sunset.gemspec
+++ b/faraday-sunset.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'faraday-sunset'
-  spec.version       = '0.1.3'
+  spec.version       = '0.2.0'
   spec.summary       = 'Automatically detect deprecated HTTP endpoints'
   spec.description   = 'Faraday middleware that sniffs responses for Sunset headers'
   spec.homepage      = 'https://github.com/philsturgeon/faraday-sunset'

--- a/faraday-sunset.gemspec
+++ b/faraday-sunset.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'faraday-sunset'
-  spec.version       = '0.1.2'
+  spec.version       = '0.1.3'
   spec.summary       = 'Automatically detect deprecated HTTP endpoints'
   spec.description   = 'Faraday middleware that sniffs responses for Sunset headers'
   spec.homepage      = 'https://github.com/philsturgeon/faraday-sunset'
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '>= 0.9.0', '< 1'
 
   spec.add_development_dependency 'appraisal', '~> 2'
+  spec.add_development_dependency 'rollbar'
   spec.add_development_dependency 'activesupport'
   spec.add_development_dependency 'coveralls', '~> 0.7'
   spec.add_development_dependency 'bundler', '~> 1.14'

--- a/lib/faraday/sunset.rb
+++ b/lib/faraday/sunset.rb
@@ -89,7 +89,7 @@ module Faraday
     def report_rollbar(warned, warning)
       begin
         report_rollbar!(warned, warning)
-      rescue
+      rescue NameError # rollbar is not present!
         # do not modify warned if an error is raised
         warned
       end
@@ -98,7 +98,7 @@ module Faraday
     def report_active_support(warned, warning)
       begin
         report_active_support!(warned, warning)
-      rescue
+      rescue NameError # active_support is not present!
         # do not modify warned if an error is raised
         warned
       end

--- a/lib/faraday/sunset.rb
+++ b/lib/faraday/sunset.rb
@@ -9,10 +9,11 @@ module Faraday
     # @param [Type] app describe app
     # @param [Hash] options = {}
     # @return void
-    def initialize(app, active_support: nil, logger: nil)
+    def initialize(app, active_support: nil, logger: nil, rollbar: nil)
       super(app)
       @active_support = active_support
       @logger = logger
+      @rollbar = rollbar
     end
 
     # @param [Faraday::Env] no idea what this does
@@ -54,6 +55,22 @@ module Faraday
         @logger.warn(warning)
         warned = true
       end
+
+      if @rollbar == 'on'
+        Rollbar.warning(warning)
+        warned = true
+      elsif @rollbar == 'auto'
+        begin
+          Rollbar.warning(warning)
+          warned = true
+        rescue
+          # ignore problems when Rollbar is missing
+          # do not modify :warned
+        end
+      else
+        # Default to 'off'
+      end
+
       unless warned
         raise NoOutputForWarning, "Pass active_support: true, or logger: ::Logger.new when registering middleware"
       end

--- a/lib/faraday/sunset.rb
+++ b/lib/faraday/sunset.rb
@@ -89,17 +89,19 @@ module Faraday
     def report_rollbar(warned, warning)
       report_rollbar!(warning)
 
-      rescue NameError # rollbar is not present!
-        # do not modify warned if an error is raised
-        warned
+    rescue NameError 
+      # rollbar is not present!
+      # do not modify warned if an error is raised
+      warned
     end
 
     def report_active_support(warned, warning)
       report_active_support!(warning)
 
-      rescue NameError # active_support is not present!
-        # do not modify warned if an error is raised
-        warned
+    rescue NameError 
+      # active_support is not present!
+      # do not modify warned if an error is raised - return warned instead
+      warned
     end
 
   end

--- a/lib/faraday/sunset.rb
+++ b/lib/faraday/sunset.rb
@@ -51,7 +51,7 @@ module Faraday
       if @active_support == :auto
         warned = report_active_support(warned, warning)
       elsif @active_support == true
-        warned = report_active_support!(warned, warning)
+        warned = report_active_support!(warning)
       end
 
       if @logger && @logger.respond_to?(:warn)
@@ -62,7 +62,7 @@ module Faraday
       if @rollbar == :auto
         warned = report_rollbar(warned, warning)
       elsif @rollbar == true
-        warned = report_rollbar!(warned, warning)
+        warned = report_rollbar!(warning)
       end
 
       unless warned
@@ -72,13 +72,13 @@ module Faraday
 
     private
 
-    def report_rollbar!(warned, warning)
+    def report_rollbar!(warning)
       Rollbar.warning(warning)
       # return true to set :warned
       true
     end
 
-    def report_active_support!(warned, warning)
+    def report_active_support!(warning)
       ActiveSupport::Deprecation.warn(warning)
       # return true to set :warned
       true
@@ -87,21 +87,19 @@ module Faraday
     # :auto methods
     # do not raise errors if gems are missing
     def report_rollbar(warned, warning)
-      begin
-        report_rollbar!(warned, warning)
+      report_rollbar!(warning)
+
       rescue NameError # rollbar is not present!
         # do not modify warned if an error is raised
         warned
-      end
     end
 
     def report_active_support(warned, warning)
-      begin
-        report_active_support!(warned, warning)
+      report_active_support!(warning)
+
       rescue NameError # active_support is not present!
         # do not modify warned if an error is raised
         warned
-      end
     end
 
   end

--- a/spec/faraday/sunset_spec.rb
+++ b/spec/faraday/sunset_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Faraday::Sunset do
       end
 
       context 'and rollbar option is enabled' do
-        context 'rollbar is "on"' do
+        context 'rollbar is true' do
           let(:options) { { rollbar: true } }
 
           it 'calls rollbar when options[:rollbar] is true' do

--- a/spec/faraday/sunset_spec.rb
+++ b/spec/faraday/sunset_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe Faraday::Sunset do
           end
         end
 
-        context 'active_support is "off" or not present' do
+        context 'active_support is false or not present' do
           let(:options) { { active_support: false } }
-          it 'does not warn when options[:active_support] is "off"' do
+          it 'does not warn when options[:active_support] is false' do
             expect{ subject.call(env) }.to raise_error(Faraday::Sunset::NoOutputForWarning)
           end
 
@@ -89,7 +89,7 @@ RSpec.describe Faraday::Sunset do
             expect{ subject.call(env) }.to raise_error(Faraday::Sunset::NoOutputForWarning)
           end
 
-          it 'does not throw an error when active_support is missing and options[:active_support] is "off"' do
+          it 'does not throw an error when active_support is missing and options[:active_support] is false' do
             allow(ActiveSupport::Deprecation).to receive(:warn) { raise NameError.new }
             expect{ subject.call(env) }.to raise_error(Faraday::Sunset::NoOutputForWarning)
           end
@@ -134,9 +134,9 @@ RSpec.describe Faraday::Sunset do
           end
         end
 
-        context 'rollbar is "off" or not present' do
+        context 'rollbar is false or not present' do
           let(:options) { { rollbar: false } }
-          it 'does not warn when options[:rollbar] is "off"' do
+          it 'does not warn when options[:rollbar] is false' do
             expect{ subject.call(env) }.to raise_error(Faraday::Sunset::NoOutputForWarning)
           end
 
@@ -145,7 +145,7 @@ RSpec.describe Faraday::Sunset do
             expect{ subject.call(env) }.to raise_error(Faraday::Sunset::NoOutputForWarning)
           end
 
-          it 'does not throw an error when rollbar is missing and options[:rollbar] is "off"' do
+          it 'does not throw an error when rollbar is missing and options[:rollbar] is false' do
             allow(Rollbar).to receive(:warning) { raise NameError.new }
             expect{ subject.call(env) }.to raise_error(Faraday::Sunset::NoOutputForWarning)
           end

--- a/spec/faraday/sunset_spec.rb
+++ b/spec/faraday/sunset_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Faraday::Sunset do
           end
 
           it 'throws an error when options[:active_support] is "on" and active_support is not present"' do
-            allow(ActiveSupport::Deprecation).to receive(:warn) { raise StandardError.new }
-            expect{ subject.call(env) }.to raise_error
+            allow(ActiveSupport::Deprecation).to receive(:warn) { raise NameError.new }
+            expect{ subject.call(env) }.to raise_error(NameError)
           end
         end
 
@@ -73,7 +73,7 @@ RSpec.describe Faraday::Sunset do
           end
 
           it 'throws an NoOutputForWarning when options[:active_support] is :auto and active_support is not present' do
-            allow(ActiveSupport::Deprecation).to receive(:warn) { raise StandardError.new }
+            allow(ActiveSupport::Deprecation).to receive(:warn) { raise NameError.new }
             expect{ subject.call(env) }.to raise_error(Faraday::Sunset::NoOutputForWarning)
           end
         end
@@ -90,7 +90,7 @@ RSpec.describe Faraday::Sunset do
           end
 
           it 'does not throw an error when active_support is missing and options[:active_support] is "off"' do
-            allow(ActiveSupport::Deprecation).to receive(:warn) { raise StandardError.new }
+            allow(ActiveSupport::Deprecation).to receive(:warn) { raise NameError.new }
             expect{ subject.call(env) }.to raise_error(Faraday::Sunset::NoOutputForWarning)
           end
         end
@@ -116,8 +116,8 @@ RSpec.describe Faraday::Sunset do
           end
 
           it 'throws an error when options[:rollbar] is "on" and rollbar is not present"' do
-            allow(Rollbar).to receive(:warning) { raise StandardError.new }
-            expect{ subject.call(env) }.to raise_error
+            allow(Rollbar).to receive(:warning) { raise NameError.new }
+            expect{ subject.call(env) }.to raise_error(NameError)
           end
         end
 
@@ -129,7 +129,7 @@ RSpec.describe Faraday::Sunset do
           end
 
           it 'throws an NoOutputForWarning when options[:rollbar] is :auto and rollbar is not present' do
-            allow(Rollbar).to receive(:warning) { raise StandardError.new }
+            allow(Rollbar).to receive(:warning) { raise NameError.new }
             expect{ subject.call(env) }.to raise_error(Faraday::Sunset::NoOutputForWarning)
           end
         end
@@ -146,7 +146,7 @@ RSpec.describe Faraday::Sunset do
           end
 
           it 'does not throw an error when rollbar is missing and options[:rollbar] is "off"' do
-            allow(Rollbar).to receive(:warning) { raise StandardError.new }
+            allow(Rollbar).to receive(:warning) { raise NameError.new }
             expect{ subject.call(env) }.to raise_error(Faraday::Sunset::NoOutputForWarning)
           end
         end
@@ -155,8 +155,8 @@ RSpec.describe Faraday::Sunset do
       context 'multiple options enabled' do
         shared_examples 'multiple options enabled' do
           it 'does not throw NoOutputForWarning if at least one message is logged' do
-            allow(missing_gem).to receive(missing_method) { raise StandardError.new }
-            expect{ subject.call(env) }.not_to raise_error(Faraday::Sunset::NoOutputForWarning)
+            allow(missing_gem).to receive(missing_method) { raise NameError.new }
+            expect{ subject.call(env) }.not_to raise_error
           end
         end
 
@@ -179,8 +179,8 @@ RSpec.describe Faraday::Sunset do
         context 'multiple options set to auto, but none are present' do
           let(:options) { { active_support: :auto, rollbar: :auto } }
           it 'does throw NoOutputForWarning if nothing is logged' do
-            allow(Rollbar).to receive(:warning) { raise StandardError.new }
-            allow(ActiveSupport::Deprecation).to receive(:warn) { raise StandardError.new }
+            allow(Rollbar).to receive(:warning) { raise NameError.new }
+            allow(ActiveSupport::Deprecation).to receive(:warn) { raise NameError.new }
             expect{ subject.call(env) }.to raise_error(Faraday::Sunset::NoOutputForWarning)
           end
         end

--- a/spec/faraday/sunset_spec.rb
+++ b/spec/faraday/sunset_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe Faraday::Sunset do
         context 'active_support is true' do
           let(:options) { { active_support: true } }
 
-          it 'calls active_support when options[:active_support] is "on"' do
+          it 'calls active_support when options[:active_support] is true' do
             expect(ActiveSupport::Deprecation).to receive(:warn).with(expected_sunset_message)
             subject.call(env)
           end
 
-          it 'throws an error when options[:active_support] is "on" and active_support is not present"' do
+          it 'throws an error when options[:active_support] is true and active_support is not present"' do
             allow(ActiveSupport::Deprecation).to receive(:warn) { raise NameError.new }
             expect{ subject.call(env) }.to raise_error(NameError)
           end
@@ -110,12 +110,12 @@ RSpec.describe Faraday::Sunset do
         context 'rollbar is "on"' do
           let(:options) { { rollbar: true } }
 
-          it 'calls rollbar when options[:rollbar] is "on"' do
+          it 'calls rollbar when options[:rollbar] is true' do
             expect(Rollbar).to receive(:warning).with(expected_sunset_message)
             subject.call(env)
           end
 
-          it 'throws an error when options[:rollbar] is "on" and rollbar is not present"' do
+          it 'throws an error when options[:rollbar] is true and rollbar is not present"' do
             allow(Rollbar).to receive(:warning) { raise NameError.new }
             expect{ subject.call(env) }.to raise_error(NameError)
           end


### PR DESCRIPTION
Add rollbar reporting into faraday-sunset, and expanded functionality of active-support

- rollbar and active-support can be configured in 3 ways:

1. `true` - also called 'on', this flag attempts to warn with rollbar or active-support, and raises an error if they are not present
2. `false` - also called 'off', this flag indicates the relevant tool will not be used
3. `auto` - this attempts to warn if possible, but if the tool is not present there is no error raised